### PR TITLE
Add `#[component]` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 > 🔏 A safe and simple template engine with the ergonomics of JSX
 
-The `Renderable` trait contains a simple function that returns `String`. This is very handy for type-safe HTML templates, but can also work for writing tree-like terminal coloring mechanism like ReasonML's [Pastel](https://reason-native.com/docs/pastel/).
+`render` itself is a combination of traits, structs and macros that together unify and
+boost the experience of composing tree-shaped data structures. This works best with HTML and
+XML rendering, but can work with other usages as well, like ReasonML's [`Pastel`](https://reason-native.com/docs/pastel/) library for terminal colors.
+
+## How?
+
+A renderable component is a struct that implements [`Renderable`](./trait.Renderable.html). There
+are multiple macros that provide a better experience implementing Renderable:
+
+* [`html!`](../render_macros/macro.html.html) for the JSX ergonomics
+* [`#[component]`](../render_macros/attr.component.html) for the syntactic-sugar of function components
 
 ## Why this is different from `typed-html`?
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Render
+# render
 
 > 🔏 A safe and simple template engine with the ergonomics of JSX
 
@@ -18,6 +18,8 @@ The `Renderable` trait contains a simple function that returns `String`. This is
 // A simple HTML 5 doctype declaration
 use render::html::HTML5Doctype;
 use render::{
+    // A macro to create components
+    component,
     // A macro to compose components in JSX fashion
     html,
     // A component that just render its children
@@ -27,28 +29,19 @@ use render::{
 };
 
 // This can be any layout we want
-#[derive(Debug)]
-struct Page<'a, T: Renderable> {
-    title: &'a str,
-    children: T,
-}
-
-// Implementing `Renderable` gives the ability to compose
-// components
-impl<'a, T: Renderable> Renderable for Page<'a, T> {
-    fn render(self) -> String {
-        html! {
-          <Fragment>
-            <HTML5Doctype />
-            <html>
-              <head><title>{self.title}</title></head>
-              <body>
-                {self.children}
-              </body>
-            </html>
-          </Fragment>
-        }
-    }
+#[component]
+fn Page<'a, Children: Renderable>(title: &'a str, children: Children) -> String {
+   html! {
+     <Fragment>
+       <HTML5Doctype />
+       <html>
+         <head><title>{title}</title></head>
+         <body>
+           {children}
+         </body>
+       </html>
+     </Fragment>
+   }
 }
 
 // This can be a route in Rocket, the web framework,
@@ -60,4 +53,7 @@ pub fn some_page(user_name: &str) -> String {
       </Page>
     }
 }
+
 ```
+
+License: MIT

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ XML rendering, but can work with other usages as well, like ReasonML's [`Pastel`
 
 ## How?
 
-A renderable component is a struct that implements [`Renderable`](./trait.Renderable.html). There
+A renderable component is a struct that implements the `Renderable` trait. There
 are multiple macros that provide a better experience implementing Renderable:
 
-* [`html!`](../render_macros/macro.html.html) for the JSX ergonomics
-* [`#[component]`](../render_macros/attr.component.html) for the syntactic-sugar of function components
+* `html!` for the JSX ergonomics
+* `#[component]` for the syntactic-sugar of function components
 
 ## Why this is different from `typed-html`?
 

--- a/render/src/lib.rs
+++ b/render/src/lib.rs
@@ -2,13 +2,13 @@
 //!
 //! The `Renderable` trait contains a simple function that returns `String`. This is very handy for type-safe HTML templates, but can also work for writing tree-like terminal coloring mechanism like ReasonML's [Pastel](https://reason-native.com/docs/pastel/).
 //!
-//! ## Why this is different from `typed-html`?
+//! # Why this is different from `typed-html`?
 //!
 //! `typed-html` is a wonderful library. Unfortunately, it focused its power in strictness of the HTML spec itself, and doesn't allow arbitrary compositions of custom elements.
 //!
 //! `render` takes a different approach. For now, HTML is not typed at all. It can get any key and get any string value. The main focus is custom components, so you can create a composable and declarative template with no runtime errors.
 //!
-//! ## Usage
+//! # Usage
 //!
 //! ```rust
 //! #![feature(proc_macro_hygiene)]

--- a/render/src/lib.rs
+++ b/render/src/lib.rs
@@ -16,6 +16,8 @@
 //! // A simple HTML 5 doctype declaration
 //! use render::html::HTML5Doctype;
 //! use render::{
+//!     // A macro to create components
+//!     component,
 //!     // A macro to compose components in JSX fashion
 //!     html,
 //!     // A component that just render its children
@@ -25,28 +27,19 @@
 //! };
 //!
 //! // This can be any layout we want
-//! #[derive(Debug)]
-//! struct Page<'a, T: Renderable> {
-//!     title: &'a str,
-//!     children: T,
-//! }
-//!
-//! // Implementing `Renderable` gives the ability to compose
-//! // components
-//! impl<'a, T: Renderable> Renderable for Page<'a, T> {
-//!     fn render(self) -> String {
-//!         html! {
-//!           <Fragment>
-//!             <HTML5Doctype />
-//!             <html>
-//!               <head><title>{self.title}</title></head>
-//!               <body>
-//!                 {self.children}
-//!               </body>
-//!             </html>
-//!           </Fragment>
-//!         }
-//!     }
+//! #[component]
+//! fn Page<'a, Children: Renderable>(title: &'a str, children: Children) -> String {
+//!    html! {
+//!      <Fragment>
+//!        <HTML5Doctype />
+//!        <html>
+//!          <head><title>{title}</title></head>
+//!          <body>
+//!            {children}
+//!          </body>
+//!        </html>
+//!      </Fragment>
+//!    }
 //! }
 //!
 //! // This can be a route in Rocket, the web framework,
@@ -80,7 +73,7 @@ mod simple_element;
 mod text_element;
 
 pub use fragment::Fragment;
-pub use render_macros::{html, rsx};
+pub use render_macros::{component, html, rsx};
 pub use renderable::Renderable;
 pub use simple_element::SimpleElement;
 pub use text_element::Raw;

--- a/render/src/lib.rs
+++ b/render/src/lib.rs
@@ -1,6 +1,16 @@
 //! > 🔏 A safe and simple template engine with the ergonomics of JSX
+//! 
+//! `render` itself is a combination of traits, structs and macros that together unify and
+//! boost the experience of composing tree-shaped data structures. This works best with HTML and
+//! XML rendering, but can work with other usages as well, like ReasonML's [`Pastel`](https://reason-native.com/docs/pastel/) library for terminal colors.
 //!
-//! The `Renderable` trait contains a simple function that returns `String`. This is very handy for type-safe HTML templates, but can also work for writing tree-like terminal coloring mechanism like ReasonML's [Pastel](https://reason-native.com/docs/pastel/).
+//! # How?
+//!
+//! A renderable component is a struct that implements [`Renderable`](./trait.Renderable.html). There
+//! are multiple macros that provide a better experience implementing Renderable:
+//!
+//! * [`html!`](../render_macros/macro.html.html) for the JSX ergonomics
+//! * [`#[component]`](../render_macros/attr.component.html) for the syntactic-sugar of function components
 //!
 //! # Why this is different from `typed-html`?
 //!

--- a/render/src/lib.rs
+++ b/render/src/lib.rs
@@ -6,11 +6,11 @@
 //!
 //! # How?
 //!
-//! A renderable component is a struct that implements [`Renderable`](./trait.Renderable.html). There
+//! A renderable component is a struct that implements the `Renderable` trait. There
 //! are multiple macros that provide a better experience implementing Renderable:
 //!
-//! * [`html!`](../render_macros/macro.html.html) for the JSX ergonomics
-//! * [`#[component]`](../render_macros/attr.component.html) for the syntactic-sugar of function components
+//! * `html!` for the JSX ergonomics
+//! * `#[component]` for the syntactic-sugar of function components
 //!
 //! # Why this is different from `typed-html`?
 //!

--- a/render/src/renderable.rs
+++ b/render/src/renderable.rs
@@ -88,3 +88,9 @@ impl<O: Renderable, E: Renderable> Renderable for Result<O, E> {
         }
     }
 }
+
+impl Renderable for usize {
+    fn render(self) -> String {
+        self.to_string()
+    }
+}

--- a/render_macros/src/function_component.rs
+++ b/render_macros/src/function_component.rs
@@ -1,0 +1,51 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::spanned::Spanned;
+
+pub fn to_component(f: syn::ItemFn) -> TokenStream {
+    let struct_name = f.sig.ident;
+    let (impl_generics, ty_generics, where_clause) = f.sig.generics.split_for_impl();
+    let inputs = f.sig.inputs;
+    let block = f.block;
+    let vis = f.vis;
+
+    let inputs_block = if inputs.len() > 0 {
+        quote!({ #inputs })
+    } else {
+        quote!(;)
+    };
+
+    let inputs_reading = if inputs.len() == 0 {
+        quote!()
+    } else {
+        let input_names: Vec<_> = inputs
+            .iter()
+            .filter_map(|argument| match argument {
+                syn::FnArg::Typed(typed) => Some(typed),
+                syn::FnArg::Receiver(rec) => {
+                    rec.span().unwrap().error("Don't use `self` on components");
+                    None
+                }
+            })
+            .map(|value| {
+                let pat = &value.pat;
+                quote!(#pat)
+            })
+            .collect();
+        quote!(
+            let #struct_name { #(#input_names),* } = self;
+        )
+    };
+
+    TokenStream::from(quote! {
+        #[derive(Debug)]
+        #vis struct #struct_name#impl_generics #inputs_block
+
+        impl#impl_generics ::render::Renderable for #struct_name #ty_generics #where_clause {
+            fn render(self) -> String {
+                #inputs_reading
+                #block
+            }
+        }
+    })
+}

--- a/render_tests/src/lib.rs
+++ b/render_tests/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(proc_macro_hygiene)]
 
 use render::html::HTML5Doctype;
-use render::{html, rsx, Fragment, Renderable};
+use render::{component, html, rsx, Fragment, Renderable};
 
 #[derive(Debug)]
 struct Hello<'a, T: Renderable> {
@@ -38,6 +38,25 @@ pub fn it_works() -> String {
         </Fragment>
     };
     value
+}
+
+#[component]
+pub fn Layout<'a, Children: Renderable>(title: &'a str, children: Children) -> String {
+    html! {
+        <html>
+            <head><title>{title}</title></head>
+            <body>
+                {children}
+            </body>
+        </html>
+    }
+}
+
+#[component]
+pub fn SomeComponent(name: String) -> String {
+    html! {
+        <div>{format!("Hello, {}", name)}</div>
+    }
 }
 
 #[test]


### PR DESCRIPTION
This closes #2, and provides better ergonomics to the macros :)