### PR TITLE
Add support for raw identifiers

### DIFF
--- a/render_macros/src/element_attributes.rs
+++ b/render_macros/src/element_attributes.rs
@@ -2,6 +2,7 @@ use crate::children::Children;
 use crate::element_attribute::ElementAttribute;
 use quote::{quote, ToTokens};
 use std::collections::HashSet;
+use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::spanned::Spanned;
 
@@ -122,9 +123,9 @@ impl<'a> ToTokens for SimpleElementAttributes<'a> {
                 .iter()
                 .map(|attribute| {
                     let mut iter = attribute.ident().iter();
-                    let first_word = iter.next().unwrap();
+                    let first_word = iter.next().unwrap().unraw();
                     let ident = iter.fold(first_word.to_string(), |acc, curr| {
-                        format!("{}-{}", acc, curr)
+                        format!("{}-{}", acc, curr.unraw())
                     });
                     let value = attribute.value_tokens();
 

--- a/render_tests/src/lib.rs
+++ b/render_tests/src/lib.rs
@@ -21,6 +21,17 @@ pub fn works_with_raw() {
 }
 
 #[test]
+pub fn works_with_raw_ident() {
+    use pretty_assertions::assert_eq;
+
+    let actual = render::html! {
+        <input r#type={"text"} />
+    };
+
+    assert_eq!(actual, r#"<input type="text"/>"#);
+}
+
+#[test]
 pub fn element_ordering() {
   use pretty_assertions::assert_eq;
     use render::{html, raw};


### PR DESCRIPTION
Introduces a workaround for #13 allowing attribute names to be prefixed with `r#` in case they overlap with rust keywords