### PR TITLE
pull out first statement to eliminate unused brace errors

### DIFF
--- a/render_macros/src/child.rs
+++ b/render_macros/src/child.rs
@@ -12,7 +12,13 @@ impl ToTokens for Child {
         match self {
             Self::Element(element) => element.to_tokens(tokens),
             Self::RawBlock(block) => {
-                let ts = quote! { #block };
+                let b = if block.stmts.len() == 1 {
+                    let first = &block.stmts[0];
+                    quote!(#first)
+                } else {
+                    quote!(#block)
+                };
+                let ts = quote! { #b };
                 ts.to_tokens(tokens);
             }
         }

--- a/render_macros/src/element_attribute.rs
+++ b/render_macros/src/element_attribute.rs
@@ -23,7 +23,14 @@ impl ElementAttribute {
 
     pub fn value_tokens(&self) -> proc_macro2::TokenStream {
         match self {
-            Self::WithValue(_, value) => quote!(#value),
+            Self::WithValue(_, value) => {
+                if value.stmts.len() == 1 {
+                    let first = &value.stmts[0];
+                    quote!(#first)
+                } else {
+                    quote!(#value)
+                }
+            }
             Self::Punned(ident) => quote!(#ident),
         }
     }


### PR DESCRIPTION
As the title says, removes unnecessary braces to prevent the unnecessary braces around function argument warnings. This eliminates 20 of the 21 warnings emitted when running cargo test.

Caveat: still a rust n00b...