### PR TITLE
github actions: combine fmt job and run on all pushes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,11 +1,5 @@
 name: Rust
-
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,18 +7,11 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: beta
+        components: rustfmt
     - uses: actions/checkout@v1
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
+    - name: Test
       run: cargo test --verbose
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: nightly
-        components: rustfmt
-    - uses: actions/checkout@v1
-    - name: cargo fmt
+    - name: Format
       run: cargo fmt -- --check


### PR DESCRIPTION
- Just one job will make it faster, formatting can be in the same one.
- Running on all push events instead of just `master`, because why not.

But it seems like pull requests are not trigger checks.. Have you possibly run out of free minutes? Not really sure how to debug it so just guessing the cause.

*Question*: should the `--verbose` be dropped? It makes the output quite noisy.