### PR TITLE
Only output self-closing tags for void elements

### DIFF
--- a/render/src/fragment.rs
+++ b/render/src/fragment.rs
@@ -15,7 +15,7 @@ use std::fmt::{Result, Write};
 ///         <b />
 ///     </>
 /// };
-/// assert_eq!(result, "<a/><b/>");
+/// assert_eq!(result, "<a></a><b></b>");
 /// ```
 #[derive(Debug)]
 pub struct Fragment<T: Render> {

--- a/render/src/html.rs
+++ b/render/src/html.rs
@@ -18,7 +18,7 @@ use std::fmt::{Result, Write};
 ///         </html>
 ///     </>
 /// };
-/// # assert_eq!(result, "<!DOCTYPE html><html><body/></html>");
+/// # assert_eq!(result, "<!DOCTYPE html><html><body></body></html>");
 /// ```
 #[derive(Debug)]
 pub struct HTML5Doctype;

--- a/render/src/simple_element.rs
+++ b/render/src/simple_element.rs
@@ -35,7 +35,17 @@ impl<T: Render> Render for SimpleElement<'_, T> {
             None => {
                 write!(writer, "<{}", self.tag_name)?;
                 write_attributes(self.attributes, writer)?;
-                write!(writer, "/>")
+
+                match self.tag_name {
+                    "area" | "base" | "br" | "col" | "embed" | "hr" | "img" | "input" | "link"
+                    | "meta" | "param" | "source" | "track" | "wbr" => {
+                        // void element, can be self-closing
+                        write!(writer, "/>")
+                    }
+                    _ => {
+                        write!(writer, "></{}>", self.tag_name)
+                    }
+                }
             }
             Some(renderable) => {
                 write!(writer, "<{}", self.tag_name)?;

--- a/render_macros/src/lib.rs
+++ b/render_macros/src/lib.rs
@@ -57,7 +57,7 @@ use syn::parse_macro_input;
 ///     <div id={"main"} />
 /// };
 ///
-/// assert_eq!(rendered, r#"<div id="main"/>"#);
+/// assert_eq!(rendered, r#"<div id="main"></div>"#);
 /// ```
 ///
 /// ### HTML entities can accept dashed-separated value
@@ -66,10 +66,10 @@ use syn::parse_macro_input;
 /// # use render_macros::html;
 /// # use pretty_assertions::assert_eq;
 /// let rendered = html! {
-///     <div data-testid={"sometestid"} />
+///     <div data-testid={"sometestid"}></div>
 /// };
 ///
-/// assert_eq!(rendered, r#"<div data-testid="sometestid"/>"#);
+/// assert_eq!(rendered, r#"<div data-testid="sometestid"></div>"#);
 /// ```
 ///
 /// ### Custom components can't accept dashed-separated values
@@ -95,7 +95,7 @@ use syn::parse_macro_input;
 ///     <div class />
 /// };
 ///
-/// assert_eq!(rendered, r#"<div class="someclass"/>"#);
+/// assert_eq!(rendered, r#"<div class="someclass"></div>"#);
 /// ```
 ///
 /// ### Punning is not supported for dashed-delimited attributes
@@ -107,7 +107,7 @@ use syn::parse_macro_input;
 ///     <div this-wont-work />
 /// };
 ///
-/// assert_eq!(rendered, r#"<div class="some_class"/>"#);
+/// assert_eq!(rendered, r#"<div class="some_class"></div>"#);
 /// ```
 #[proc_macro]
 #[proc_macro_error]

--- a/render_tests/src/lib.rs
+++ b/render_tests/src/lib.rs
@@ -9,7 +9,7 @@ fn works_with_dashes() {
     use pretty_assertions::assert_eq;
 
     let value = render::html! { <div data-id={"myid"} /> };
-    assert_eq!(value, r#"<div data-id="myid"/>"#);
+    assert_eq!(value, r#"<div data-id="myid"></div>"#);
 }
 
 #[test]
@@ -41,7 +41,18 @@ fn works_with_keywords() {
     use render::html;
 
     assert_eq!(html! { <input type={"text"} /> }, r#"<input type="text"/>"#);
-    assert_eq!(html! { <label for={"me"} /> }, r#"<label for="me"/>"#);
+    assert_eq!(
+        html! { <label for={"me"} /> },
+        r#"<label for="me"></label>"#
+    );
+}
+
+#[test]
+fn selfclosing_void_element() {
+    use pretty_assertions::assert_eq;
+    use render::html;
+
+    assert_eq!(html! { <hr /> }, r#"<hr/>"#);
 }
 
 #[test]


### PR DESCRIPTION
From my reading of the spec, self-closing tags are only allowed for void elements of foreign elements. Not sure if there's any case where it's actually required, so for now I've changed it to only use self-closing tags for known void elements.

Should resolve #42 