### PR TITLE
fix: Correct handling of empty non self-closing elements

### DIFF
--- a/render/src/simple_element.rs
+++ b/render/src/simple_element.rs
@@ -13,6 +13,7 @@ pub struct SimpleElement<'a, T: Render> {
     pub tag_name: &'a str,
     pub attributes: Attributes<'a>,
     pub contents: Option<T>,
+    pub self_closing: bool,
 }
 
 fn write_attributes<'a, W: Write>(maybe_attributes: Attributes<'a>, writer: &mut W) -> Result {
@@ -31,19 +32,16 @@ fn write_attributes<'a, W: Write>(maybe_attributes: Attributes<'a>, writer: &mut
 
 impl<T: Render> Render for SimpleElement<'_, T> {
     fn render_into<W: Write>(self, writer: &mut W) -> Result {
-        match self.contents {
-            None => {
-                write!(writer, "<{}", self.tag_name)?;
-                write_attributes(self.attributes, writer)?;
-                write!(writer, "/>")
-            }
-            Some(renderable) => {
-                write!(writer, "<{}", self.tag_name)?;
-                write_attributes(self.attributes, writer)?;
-                write!(writer, ">")?;
-                renderable.render_into(writer)?;
-                write!(writer, "</{}>", self.tag_name)
-            }
+        if self.self_closing {
+            write!(writer, "<{}", self.tag_name)?;
+            write_attributes(self.attributes, writer)?;
+            write!(writer, "/>")
+        } else {
+            write!(writer, "<{}", self.tag_name)?;
+            write_attributes(self.attributes, writer)?;
+            write!(writer, ">")?;
+            self.contents.render_into(writer)?;
+            write!(writer, "</{}>", self.tag_name)
         }
     }
 }

--- a/render_tests/src/lib.rs
+++ b/render_tests/src/lib.rs
@@ -78,6 +78,18 @@ fn element_ordering() {
 }
 
 #[test]
+fn childless_non_selfclosing_tag() {
+    use pretty_assertions::assert_eq;
+    use render::html;
+
+    let actual = html! {
+        <textarea></textarea>
+    };
+
+    assert_eq!(actual, "<textarea></textarea>");
+}
+
+#[test]
 fn some_none() {
     use pretty_assertions::assert_eq;
     use render::{component, html, rsx};


### PR DESCRIPTION
Previously empty element tags were causing other elements to be incorrectly rendered inside them.

This commit fixes the issue by ensuring that empty non self-closing tags are handled correctly.

Closes #42